### PR TITLE
Update SMTP testing instructions & add aiosmtpd dep

### DIFF
--- a/envs/environment-dev.yaml
+++ b/envs/environment-dev.yaml
@@ -34,6 +34,9 @@ dependencies:
   - pyyaml
   - requests
 
+  # For capturing email messages during testing
+  - aiosmtpd
+
   # For coding style, repo QA, and package management
   - black
   - hatch

--- a/run/config.yaml
+++ b/run/config.yaml
@@ -60,7 +60,7 @@ logging:
   toaddrs:
     - sallen@eoas.ubc.ca
   # Run
-  #    python -m smtpd -n -c DebuggingServer localhost:1025
+  #    python -m aiosmtpd -n -l localhost:1025
   # to capture email messages for testing
   use_test_smtpd: False
 


### PR DESCRIPTION
Update the example command in `config.yaml` to use `aiosmtpd` for testing email capture. Added `aiosmtpd` to the development environment dependencies to support this functionality. This addresses the removal of the `smtpd` module from the Python 3.12 standard library.