### PR TITLE
Fix river data parsing bug

### DIFF
--- a/bloomcast/rivers.py
+++ b/bloomcast/rivers.py
@@ -84,7 +84,7 @@ class RiversProcessor(ForcingDataProcessor):
         for line in Path(getattr(self.config.rivers, river).file).open("rt"):
             line_date = arrow.get(*(map(int, line.split()[:3])))
             if start_date <= line_date <= end_date:
-                self.raw_data.append(line)
+                self.raw_data.append(f"{line.split("#", 1)[0].strip()}\n")
 
     def _date_range(self, start_year):
         """


### PR DESCRIPTION
Exclude comments in obs file from raw data collection.

Updated river data parsing logic to exclude comments in obs files from being collected as raw data. This change avoids a `ValueError` exception that was misinterpreted as an unchanged wind data date that stopped processing.